### PR TITLE
Add Block Protocol to README and improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # HASH DMCA Notice Public Archive
 
 **What is this?**
-Inspired by Lumen (formerly Chilling Effects), Google, and [GitHub's own public archive](https://github.com/github/dmca), this repository contains the text of DMCA takedown notices and counter-notices we've received here at HASH. We publish them as they are received, with only personally identifiable information redacted.
+Inspired by Lumen (formerly Chilling Effects), Google, and [GitHub's own public archive](https://github.com/github/dmca), this repository contains the text of DMCA takedown notices and counter-notices we've received here at HASH in relation to the [HASH global graph](https://hash.ai/) or the [Block Protocol Hub](https://blockprotocol.org/hub). We publish them as they are received, with only personally identifiable information redacted.
 
 **Why is this?**
-In short, we believe that transparency on a specific and ongoing level is essential to good governance. Chilling Effects explained it well in 2014 (no longer available online): "We are excited about the new opportunities the Internet offers individuals to express their views . . . but concerned that not everyone feels the same way. Study to date suggests that cease and desist letters often silence Internet users, whether or not their claims have legal merit." (About, ChillingEffects.org, Sept. 2014, licensed under [CC-BY-3.0](http://creativecommons.org/licenses/by/3.0/us/)). Similarly, we post takedown notices here to document their potential to "chill" speech.
+In short, we believe that transparency on a specific and ongoing basis is essential to good governance. Chilling Effects explained it well in 2014 (no longer available online): "We are excited about the new opportunities the Internet offers individuals to express their views . . . but concerned that not everyone feels the same way. Study to date suggests that cease and desist letters often silence Internet users, whether or not their claims have legal merit." (About, ChillingEffects.org, Sept. 2014, licensed under [CC-BY-3.0](http://creativecommons.org/licenses/by/3.0/us/)). Similarly, we post takedown notices here to document their potential to "chill" speech.
 
 **What does it mean if there's a notice posted here?**
 It only means that we received the notice on the indicated date. It does not mean that the content was unlawful or wrong. It does not mean that the user identified in the notice has done anything wrong. We don't make or imply any judgment about the merit of the claims they make. We post these notices and requests only for informational purposes. *For more details, see our [DMCA Policy](https://hash.ai/legal/copyright).*
 
 **How can I serve HASH with a DMCA notice or counter notice?**
-If you would like to submit a DMCA notice or counter notice, see our [DMCA Policy](https://hash.ai/legal/copyright) for information on how to do so.
+If you would like to submit a DMCA notice, see our page on [submitting a DMCA notice](https://hash.ai/legal/copyright-dmca-notice). If you have received a notice you feel is inaccurate or invalid, see [submitting a DMCA counter-notice](https://hash.ai/legal/copyright-dmca-counter-notice).
 
 **Contributing**
 We do not accept Pull Requests in this repository. Feel free to comment or make suggestions, but note that we do not actively monitor contributions to this repository. If you would like to contact HASH about this repository, please do so [via the website](https://hash.ai/contact).


### PR DESCRIPTION
Improves clarity and direct-links to both notice and counter-notice submission "how-to" pages rather than the general DMCA policy page.